### PR TITLE
fix(options): windows support

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -18,7 +18,7 @@ export default async function module(moduleOptions) {
   this.extendBuild(extendBuild.bind(this))
 
   options._input = options.input
-  options.input = resolve(options.input)
+  options.input = resolve(options.input).replace(/\//g, path.sep);
   options.output = resolve(options.output)
 
   await init.call(this, options)

--- a/lib/module.js
+++ b/lib/module.js
@@ -13,12 +13,15 @@ const DEFAULTS = {
 
 export default async function module(moduleOptions) {
   const options = { ...DEFAULTS, ...moduleOptions, ...this.options.svgSprite }
-  const resolve = path => path.replace('~', this.nuxt.options.srcDir)
+  const resolve = $path => $path
+    .replace(/\//g, path.sep)
+    .replace('~', this.nuxt.options.srcDir)
 
   this.extendBuild(extendBuild.bind(this))
 
   options._input = options.input
-  options.input = resolve(options.input.replace(/\//g, path.sep));
+  options._output = options.output
+  options.input = resolve(options.input)
   options.output = resolve(options.output)
 
   await init.call(this, options)

--- a/lib/module.js
+++ b/lib/module.js
@@ -18,7 +18,7 @@ export default async function module(moduleOptions) {
   this.extendBuild(extendBuild.bind(this))
 
   options._input = options.input
-  options.input = resolve(options.input).replace(/\//g, path.sep);
+  options.input = resolve(options.input.replace(/\//g, path.sep));
   options.output = resolve(options.output)
 
   await init.call(this, options)

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -32,7 +32,7 @@ const svgIcon = {
         sprite = '<%= options.defaultSprite %>'
       }
 
-      return require('<%= relativeToBuild(options.output) %>/' + sprite + '.svg') +
+      return require('<%= relativeToBuild(options._output) %>/' + sprite + '.svg') +
                 `#i-${generateName(icon)}`
     }
   },


### PR DESCRIPTION
a workaround for icons not being generated correctly after changing an SVG which was caused by the backward slashes inside ``nuxt.options.srcDir``. Solves it by replacing the path with ``path.sep`` which is OS-specific.