### PR TITLE
fix: use PascalCase for component registration name

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,7 +8,8 @@ function generateName(name) {
 }
 
 // @vue/component
-const svgIcon = {
+const SvgIcon = {
+  name: 'SvgIcon',
   props: {
     name: {
       type: String,
@@ -54,4 +55,4 @@ const svgIcon = {
   }
 }
 
-Vue.component('svgIcon', svgIcon)
+Vue.component(SvgIcon.name, SvgIcon)


### PR DESCRIPTION
Vue recommends using PascalCase for component registration. This allows users to use both PascalCase and kebab-case in their apps