### PR TITLE
feat: define global and sprite specific class

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ Add `@nuxtjs/svg-sprite` to modules section of `nuxt.config.js`:
 {
   modules: [
     '@nuxtjs/svg-sprite',
- ]
+  ],
+  svgSprite: {
+    // manipulate module options
+  }
 }
 ```
 
@@ -45,13 +48,14 @@ To create different sprites, create custom directory inside `~/assets/sprite/svg
 
 Module default options:
 
-```js
-{
-  input: '~/assets/sprite/svg',
-  output: '~/assets/sprite/gen',
-  defaultSprite: 'icons'
-}
-```
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| input | `~/assets/sprite/svg` | Directory of original svg files |
+| output | `~/assets/sprite/gen` | Directory to store generated sprites |
+| defaultSprite | `icons` | Name of default sprite (default sprite consist of all svgs that place directly inside `input` directory) |
+| elementClass | `icon` | global class of all `<svg-icon>` instances |
+| spriteClassPrefix | `sprite-` | Prefix of sprite specific classes |
 
 You can update them with the `svgSprite` option in `nuxt.config.js`:
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -8,7 +8,9 @@ const logger = consola.withScope('@nuxtjs/svg-sprite')
 const DEFAULTS = {
   input: '~/assets/sprite/svg',
   output: '~/assets/sprite/gen',
-  defaultSprite: 'icons'
+  defaultSprite: 'icons',
+  elementClass: 'icon',
+  spriteClassPrefix: 'sprite-'
 }
 
 export default async function module(moduleOptions) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -34,14 +34,20 @@ const SvgIcon = {
     }
   },
   computed: {
-    icon() {
+    info() {
       let [sprite, icon] = this.name.split('/')
 
       if (!icon) {
         icon = sprite
         sprite = '<%= options.defaultSprite %>'
       }
-
+      return {
+        icon,
+        sprite
+      }
+    },
+    icon() {
+      const { icon, sprite } = this.info
       return require('<%= relativeToBuild(options._output) %>/' + sprite + '.svg') +
                 `#i-${generateName(icon)}`
     }
@@ -57,10 +63,13 @@ const SvgIcon = {
     })
     const title = this.title ? h('title', this.title) : null
     const desc = this.desc ? h('desc', this.desc) : null
+
+    const { sprite } = this.info
     return h('svg', {
       attrs: {
         xmlns: 'http://www.w3.org/2000/svg',
-        viewBox: this.viewBox
+        viewBox: this.viewBox,
+        class: '<%= options.elementClass %> <%= options.spriteClassPrefix %>' + sprite
       }
     },
     [ title, desc, use ].filter(Boolean)


### PR DESCRIPTION
In order to better styling module adds a global class to all svg tags, also sprite names will add as tags class with defined prefix
Fixs #53