### PR TITLE
feat: include only output dir

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -19,7 +19,23 @@ export default async function module(moduleOptions) {
     .replace(/\//g, path.sep)
     .replace('~', this.nuxt.options.srcDir)
 
-  this.extendBuild(extendBuild.bind(this))
+  this.extendBuild(config => {
+    const urlLoader = config.module.rules.find(rule => String(rule.test).includes('svg'))
+    urlLoader.test = /\.(png|jpe?g|gif)$/
+
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: [{
+        loader: 'url-loader',
+        options: {
+          limit: 12,
+          include: [
+            path.resolve(options.output)
+          ]
+        },
+      }]
+    })
+  })
 
   options._input = options.input
   options._output = options.output
@@ -85,20 +101,5 @@ function setupHooks(options) {
       options._filesWatcher.close()
       delete options._filesWatcher
     }
-  })
-}
-
-function extendBuild(config) {
-  const urlLoader = config.module.rules.find(rule => String(rule.test).includes('svg'))
-  urlLoader.test = /\.(png|jpe?g|gif)$/
-
-  config.module.rules.push({
-    test: /\.svg$/,
-    use: [{
-      loader: 'url-loader',
-      options: {
-        limit: 12
-      }
-    }]
   })
 }


### PR DESCRIPTION
Added `include` option to the rule, so user can have it's own defined svg-rules for `.svg` files.