### PR TITLE
fix: move class outside of attrs

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -69,7 +69,8 @@ const SvgIcon = {
       attrs: {
         xmlns: 'http://www.w3.org/2000/svg',
         viewBox: this.viewBox,
-        class: '<%= options.elementClass %> <%= options.spriteClassPrefix %>' + sprite
+        // prefer staticClass over class – custom user classes are not applied till require is complete
+        staticClass: '<%= options.elementClass %> <%= options.spriteClassPrefix %>' + sprite
       }
     },
     [ title, desc, use ].filter(Boolean)

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -66,11 +66,10 @@ const SvgIcon = {
 
     const { sprite } = this.info
     return h('svg', {
+      class: '<%= options.elementClass %> <%= options.spriteClassPrefix %>' + sprite,
       attrs: {
         xmlns: 'http://www.w3.org/2000/svg',
-        viewBox: this.viewBox,
-        // prefer staticClass over class – custom user classes are not applied till require is complete
-        staticClass: '<%= options.elementClass %> <%= options.spriteClassPrefix %>' + sprite
+        viewBox: this.viewBox
       }
     },
     [ title, desc, use ].filter(Boolean)


### PR DESCRIPTION
I have an error in my project. Since you are using require in your computed property `icon`. My custom icon classes are not applied during initial rendering. It's causing that styles that contain that classes are not applied. To reproduce an error just set Low-end mobile speed on Chrome. I suggest you to use `staticClass` instead, so user custom classes are always applied.

![error](https://user-images.githubusercontent.com/44983823/64076380-c9a5ed00-cccc-11e9-977e-5f9aa0faee39.png)

If you merge this PR, it would be great if you can upload a new patch release on npm.

P.S. I have and idea to convert this component to functional component, so there are performance boost. What do you think about it? Can I start implementing it?