### PR TITLE
feat: use functional component

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import { mergeData } from 'vue-functional-data-merge'
 
 function generateName (name) {
   return name
@@ -7,9 +8,30 @@ function generateName (name) {
     .replace(/[^a-z0-9-]/g, '-')
 }
 
+function getIcon (info) {
+  const { icon, sprite } = info
+  return require('<%= relativeToBuild(options._output) %>/' + sprite + '.svg') +
+            `#i-${generateName(icon)}`
+}
+
+function getInfo (name) {
+  let [sprite, icon] = name.split('/')
+
+  if (!icon) {
+    icon = sprite
+    sprite = '<%= options.defaultSprite %>'
+  }
+
+  return {
+    icon,
+    sprite
+  }
+}
+
 // @vue/component
 const SvgIcon = {
   name: 'SvgIcon',
+  functional: true,
   props: {
     name: {
       type: String,
@@ -33,45 +55,34 @@ const SvgIcon = {
       }
     }
   },
-  computed: {
-    info () {
-      let [sprite, icon] = this.name.split('/')
+  render (h, { props, data }) {
+    const info = getInfo(props.name)
+    const icon = getIcon(info)
 
-      if (!icon) {
-        icon = sprite
-        sprite = '<%= options.defaultSprite %>'
-      }
-      return {
-        icon,
-        sprite
-      }
-    },
-    icon () {
-      const { icon, sprite } = this.info
-      return require('<%= relativeToBuild(options._output) %>/' + sprite + '.svg') +
-                `#i-${generateName(icon)}`
-    }
-  },
-  render (h) {
     const use = h('use', {
       attrs: {
         // Since SVG 2, the xlink:href attribute is deprecated in favor of simply href.
-        href: this.icon,
+        href: icon,
         // xlink:href can still be required in practice for cross-browser compatibility.
-        'xlink:href': this.icon
+        'xlink:href': icon
       }
     })
-    const title = this.title ? h('title', this.title) : null
-    const desc = this.desc ? h('desc', this.desc) : null
 
-    const { sprite } = this.info
-    return h('svg', {
+    const title = props.title ? h('title', props.title) : null
+    const desc = props.desc ? h('desc', props.desc) : null
+
+    const { sprite } = info
+
+    const componentData = {
       class: '<%= options.elementClass %> <%= options.spriteClassPrefix %>' + sprite,
       attrs: {
         xmlns: 'http://www.w3.org/2000/svg',
-        viewBox: this.viewBox
+        viewBox: props.viewBox
       }
-    },
+    }
+
+    return h('svg',
+    mergeData(data, componentData),
     [ title, desc, use ].filter(Boolean)
     )
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chalk": "^2.4.2",
     "consola": "^2.10.1",
     "fs-extra": "^8.1.0",
-    "svgo": "^1.3.0"
+    "svgo": "^1.3.0",
+    "vue-functional-data-merge": "^3.1.0"
   }
 }


### PR DESCRIPTION
Icon is such a small representative component, so probably, it should not contain any state. Rewrote it using **functional** stateless components.

From Vue.js [docs](https://vuejs.org/v2/guide/render-function.html#Functional-Components):

> Since functional components are just functions, they’re much cheaper to render.