### PR TITLE
Inline definitions

### DIFF
--- a/demo/assets/sprite/svg/empty-defs/add.svg
+++ b/demo/assets/sprite/svg/empty-defs/add.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="8" height="8" viewBox="0 0 8 8">
+    <defs>
+        <path id="a" d="M7.5 7.5V4.533c0-.666 1-.666 1 0V8a.5.5 0 0 1-.5.5H4.533c-.666 0-.666-1 0-1H7.5zm1 1v2.967c0 .666-1 .666-1 0V8a.5.5 0 0 1 .5-.5h3.467c.666 0 .666 1 0 1H8.5z"/>
+    </defs>
+    <use fill="#111" fill-rule="nonzero" transform="translate(-4 -4)" xlink:href="#a"/>
+</svg>

--- a/demo/pages/empty-defs.vue
+++ b/demo/pages/empty-defs.vue
@@ -1,0 +1,3 @@
+<template>
+  <SvgIcon class="add-icon" name="empty-defs/add" />
+</template>

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -82,8 +82,8 @@ const SvgIcon = {
     }
 
     return h('svg',
-    mergeData(data, componentData),
-    [ title, desc, use ].filter(Boolean)
+      mergeData(data, componentData),
+      [ title, desc, use ].filter(Boolean)
     )
   }
 }

--- a/lib/plugins/inlineDefs.js
+++ b/lib/plugins/inlineDefs.js
@@ -1,0 +1,214 @@
+'use strict'
+
+/**
+ * @author marinewater
+ * https://github.com/svg/svgo/pull/976
+ */
+
+const JSAPI = require('svgo/lib/svgo/jsAPI.js')
+
+exports.type = 'full'
+exports.active = true
+exports.description = 'inlines svg definitions'
+
+/**
+ * plugin options
+ * @typedef {{onlyUnique: boolean}} Params
+ */
+exports.params = {
+  onlyUnique: false
+}
+
+/**
+ * replaces use tag with the corresponding definitions
+ * if onlyUnique = true, replaces only use tags with definitions referred to only once
+ * @param {Object} document
+ * @param {Params} params
+ * @returns {Object}
+ */
+exports.fn = function (document, params) {
+  const defs = document.querySelector('defs')
+  const uses = document.querySelectorAll('use')
+
+  if (!uses) {
+    return document
+  }
+
+  const useCount = _countUses(uses)
+
+  for (let i = 0; i < uses.length; i++) {
+    let hrefItem = uses[i].attr('xlink:href')
+    if (!hrefItem) {
+      hrefItem = uses[i].attr('href')
+    }
+    const href = hrefItem.value
+
+    if (params.onlyUnique === true && useCount[href] > 1) {
+      continue
+    }
+
+    const x = uses[i].hasAttr('x') ? uses[i].attr('x').value : null
+    const y = uses[i].hasAttr('y') ? uses[i].attr('y').value : null
+
+    let attrValue = null
+    if (x && y) {
+      attrValue = 'translate(' + x + ', ' + y + ')'
+    } else if (x) {
+      attrValue = 'translate(' + x + ')'
+    }
+
+    let def = _findById(defs, href.match(idRegex)[1])
+    if (!def) {
+      continue
+    }
+    if (params.onlyUnique === true && useCount[href] === 1) {
+      def = _replaceElement(def)
+    }
+
+    for (const key in uses[i].attrs) {
+      if (uses[i].attrs.hasOwnProperty(key) && key !== 'x' && key !== 'y' && key !== 'xlink:href' && key !== 'href') {
+        def.addAttr(uses[i].attrs[key])
+      }
+    }
+
+    if (attrValue) {
+      const g = new JSAPI({
+        elem: 'g',
+        attrs: {
+          transform: {
+            name: 'transform',
+            value: attrValue,
+            prefix: null,
+            local: 'transform'
+          }
+        },
+        content: [def]
+      })
+      _replaceElement(uses[i], g)
+    } else {
+      _replaceElement(uses[i], def)
+    }
+  }
+
+  if (params.onlyUnique === false) {
+    for (const element in useCount) {
+      if (useCount.hasOwnProperty(element) && useCount[element] > 1) {
+        const tags = document.querySelectorAll(element)
+        for (let j = 0; j < tags.length; j++) {
+          tags[j].removeAttr('id')
+        }
+      }
+    }
+  }
+
+  _removeDefs(document, params)
+
+  return document
+}
+
+/**
+ * removes defs tag from the svg if possible
+ * @param {Object} document
+ * @param {Object} params
+ * @private
+ */
+function _removeDefs (document, params) {
+  if (params.onlyUnique === false || document.querySelector('defs').content.length === 0) {
+    _replaceElement(document.querySelector('defs'))
+  }
+}
+
+/**
+ * counts the number of uses of definitions
+ * @param {Array} elements
+ * @returns {Object<string, number>}
+ * @private
+ */
+function _countUses (elements) {
+  return elements.reduce(function (result, item) {
+    let hrefItem = item.attr('xlink:href')
+    if (!hrefItem) {
+      hrefItem = item.attr('href')
+    }
+    const href = hrefItem.value
+
+    if (result.hasOwnProperty(href)) {
+      result[href]++
+    } else {
+      result[href] = 1
+    }
+
+    return result
+  }, {})
+}
+
+/**
+ * replace element with another
+ * if newElement is omitted, oldElement will be removed without replacement
+ * @param {Object} oldElement
+ * @param {Object} [newElement]
+ * @returns {Object}
+ * @private
+ */
+function _replaceElement (oldElement, newElement) {
+  const elementIndex = _getElementIndex(oldElement)
+
+  if (newElement) {
+    oldElement.parentNode.spliceContent(elementIndex, 1, newElement)
+  } else {
+    oldElement.parentNode.spliceContent(elementIndex, 1)
+  }
+
+  return oldElement
+}
+
+/**
+ * returns index of the element in the list of siblings
+ * returns -1 if element could not be found
+ * @param {Object} element
+ * @returns {number}
+ * @private
+ */
+function _getElementIndex (element) {
+  element.addAttr({
+    name: 'data-defs-index',
+    value: 'true',
+    prefix: '',
+    local: 'data-defs-index'
+  })
+
+  const index = element.parentNode.content.findIndex(function (contentElement) {
+    return contentElement.hasAttr('data-defs-index', 'true')
+  })
+
+  element.removeAttr('data-defs-index')
+
+  return index
+}
+
+const idRegex = /^#?(\S+)/
+
+/**
+ * finds the first appearance of element with id = "id"
+ * (querySelector does not seam to handle multiple id ta
+ * @param {Object} element
+ * @param {string} id
+ * @returns {Object|null}
+ * @private
+ */
+function _findById (element, id) {
+  if (element.hasAttr('id', id)) {
+    return element
+  }
+
+  if (element.content) {
+    for (let i = 0; i < element.content.length; i++) {
+      const result = _findById(element.content[i], id)
+      if (result !== null) {
+        return result
+      }
+    }
+  }
+
+  return null
+}

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -5,6 +5,7 @@ import removeAttrs from 'svgo/plugins/removeAttrs'
 import removeDimensions from 'svgo/plugins/removeDimensions'
 import removeViewBox from 'svgo/plugins/removeViewBox'
 import inlineStyles from 'svgo/plugins/inlineStyles'
+import inlineDefs from './plugins/inlineDefs'
 
 // Enable removeAttrs plugin
 // Remove id attribute to prevent conflict with our id
@@ -22,12 +23,13 @@ inlineStyles.active = true
 inlineStyles.params.onlyMatchedOnce = false
 
 const svgOptimizer = new Svgo({
-  pluging: [
+  plugins: [
     removeDimensions,
     cleanupIDs,
     removeAttrs,
     removeViewBox,
-    inlineStyles
+    inlineStyles,
+    { inlineDefs }
   ]
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -52,3 +52,22 @@ describe('Render module', () => {
     }
   })
 })
+
+describe('Inline Definitions', () => {
+  beforeEach(async () => {
+    await page.goto(url('/empty-defs'))
+  })
+
+  test('<defs> should not have any content', async () => {
+    const spritePath = await page.evaluate(() => {
+      const element = document.querySelector('.add-icon use')
+      return element.getAttribute('xlink:href')
+    })
+
+    await page.goto(url(spritePath))
+
+    const content = await page.content()
+
+    expect(content).toMatch(/<defs>[^\w0-9]*<\/defs>/)
+  })
+})


### PR DESCRIPTION
Many of SVG file contains definitions when the module tries to merge these SVG images, definition with save id conflict with each other and result is not a valid image.  
Unfortunately, there is no official module to solve this issue. Also, Svgo does not maintain in past months and all PRs left unchecked.

`inlineDefs` remove use tags and replace them with the corresponding definition. This plugin has used from https://github.com/svg/svgo/pull/976
