### PR TITLE
feat(icons-list): make icons list page optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To create different sprites, create custom directory inside `~/assets/sprite/svg
 <svg-icon name="my-sprite/my-image" />
 ```
 
-Module create a page that list all of icons for you, by default you can see this page in `/_icons` path.  
+Module create a page that list all of icons for you, by default you can see this page in `/_icons` path.
 **Note:** This page creates in `dev` mode, So you can't see it in production.
 
 ## Options
@@ -64,7 +64,8 @@ Module default options:
 | elementClass | `icon` | global class of all `<svg-icon>` instances |
 | spriteClassPrefix | `sprite-` | Prefix of sprite specific classes |
 | publicPath | `null` | Specifies a custom public path for the sprites |
-| iconsPath | `_icons` | Custom path fro icons list page |
+| buildIconsList | `true` | Create a page that list all the icons |
+| iconsPath | `_icons` | Custom path for icons list page |
 | svgoConfig | `null` | Custom config object for SVGO, [How to customize SVGO config](/docs/svgo-config.md) |
 
 You can update them with the `svgSprite` option in `nuxt.config.js`:

--- a/lib/module.js
+++ b/lib/module.js
@@ -14,7 +14,8 @@ const DEFAULTS = {
   elementClass: 'icon',
   spriteClassPrefix: 'sprite-',
   publicPath: null,
-  iconsPath: '/_icons'
+  iconsPath: '/_icons',
+  buildIconsList: true,
 }
 
 let svgManager
@@ -44,7 +45,7 @@ export default async function module (moduleOptions) {
     options
   })
 
-  if (this.nuxt.options.dev) {
+  if (options.buildIconsList && this.nuxt.options.dev) {
     // register page
     this.nuxt.hook('build:extendRoutes', (routes) => {
       routes.push({


### PR DESCRIPTION
This commit adds a module option called `buildIconsList` that triggers
the creation of the icons list page in development mode, previously
added in 4425e7c54d ("feat(icons-list): list all icons in a single page
on dev mode (#108)").

This effectively makes possible to disable the creation of this test
page in development mode; although it has been kept to true as default,
so it will be built unless told otherwise in nuxt.config.js.