### PR TITLE
fix(module): dev template generation bug

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -45,17 +45,19 @@ export default async function module (moduleOptions) {
   })
 
   if (this.nuxt.options.dev) {
+    const componentPath = path.resolve(this.nuxt.options.buildDir, 'nuxt-svg-sprite-icons-list.vue')
+
     this.addTemplate({
       src: path.resolve(__dirname, 'pages', 'icons-list.vue'),
       fileName: 'nuxt-svg-sprite-icons-list.vue',
       options
     })
     // register page
-    this.nuxt.hook('build:extendRoutes', (routes) => {
+    this.extendRoutes(function(routes) {
       routes.push({
         name: 'icons-list',
         path: options.iconsPath,
-        component: path.resolve(this.nuxt.options.buildDir, 'nuxt-svg-sprite-icons-list.vue')
+        component: componentPath
       })
     })
   }


### PR DESCRIPTION
According to this https://github.com/nuxt-community/svg-sprite-module/issues/120 bug, it successfully worked, after I changed to use extendRoutes API instead of hook to trigger the process of extending routes. 

This might be helpful: https://github.com/nuxt/nuxt.js/issues/6516