### PR TITLE
Chore: Update `package.json` info fields with urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Optimized and Easy way to use svg files in Nuxt.js",
   "main": "lib/module.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nuxt-community/svg-sprite-module.git"
+  },
+  "homepage": "https://github.com/nuxt-community/svg-sprite-module#readme",
+  "bugs": {
+    "url": "https://github.com/nuxt-community/svg-sprite-module/issues"
+  },
   "scripts": {
     "dev": "nuxt dev demo",
     "lint": "eslint --ext .js,.vue .",


### PR DESCRIPTION
This PR adds a bunch of fields to `package.json` file with urls related to the package repository. 
Primarily it was made for info purposes in various command line tools, so you can quickly navigate to either issues or readme package sections.