### PR TITLE
fix vue errors in template

### DIFF
--- a/lib/pages/icons-list.vue
+++ b/lib/pages/icons-list.vue
@@ -8,7 +8,7 @@
       <div class="content">
         <div
           v-for="symbol in sprite.symbols"
-          :key="symbol"
+          :key="symbol.path"
           class="icon-box"
         >
           <div class="icon-svg">


### PR DESCRIPTION
```
[Vue warn]: Avoid using non-primitive value as key, use string/number value instead.
[Vue warn]: Duplicate keys detected: '[object Object]'. This may cause an update error.
```
