### PR TITLE
fix route for icons list page

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -54,7 +54,7 @@ export default async function module (moduleOptions) {
     })
     // register page
     this.extendRoutes(function svgModuleExtendRoutes (routes) {
-      routes.push({
+      routes.unshift({
         name: 'icons-list',
         path: options.iconsPath,
         component: componentPath


### PR DESCRIPTION
Place route for icons list page in top, as it could be override by routes generated by nuxt.

For example:
```
{
    name: 'all',
    path: '/*',
    component: 'pages/_.vue',
    chunkName: 'pages/_',
  }

```
