### PR TITLE
fix(icons-page): add color for icon name

### DIFF
--- a/lib/pages/icons-list.vue
+++ b/lib/pages/icons-list.vue
@@ -102,6 +102,7 @@ export default {
     overflow: hidden;
     white-space: nowrap;
     background: #f8f8f8;
+    color: #000;
     direction: ltr;
     text-align: center;
     border: none;


### PR DESCRIPTION
Currently, the icon name on the icons page uses a globally set color. It works badly when the global font color is light...
![image](https://user-images.githubusercontent.com/3998654/94299442-5a9ed480-ff70-11ea-891d-1067bc281fe2.png)
