### PR TITLE
fix: always keep modulee alias to prevent storybook error

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -79,6 +79,9 @@ export default async function module (moduleOptions) {
   this.nuxt.hook('storybook:config', ({ stories }) => {
     stories.push('@nuxtjs/svg-sprite/stories/*.stories.js')
   })
+
+  // alias output dir
+  nuxt.options.alias['~svgsprite'] = options.output
 }
 
 function watchFiles (options) {


### PR DESCRIPTION
Alway ass module alias

fix: https://github.com/nuxt-community/storybook/issues/155