### PR TITLE
style(plugin): better formatting

### DIFF
--- a/src/runtime/plugin.js
+++ b/src/runtime/plugin.js
@@ -1,15 +1,14 @@
 import svgSprite from '~svg-sprite-runtime'
 
 const SPRITES = {
-<%= options.sprites.map(key => `"${key}": () => import('${relativeToBuild(options.output)}/${key}.svg')`).join(',') %>
+  <%= options.sprites.map(key => `'${key}': () => import('${relativeToBuild(options.output)}/${key}.svg')`).join(',\n  ') %>
 }
 
-export default function(context, inject) {
-    inject('svgSprite', svgSprite({
-        importSprite: key => SPRITES[key] ? SPRITES[key]() : Promise.resolve(""),
-        defaultSprite: '<%= options.defaultSprite %>',
-        spriteClassPrefix: '<%= options.spriteClassPrefix %>',
-        spriteClass: '<%= options.elementClass %>',
-    }))
+export default function (_, inject) {
+  inject('svgSprite', svgSprite({
+    importSprite: key => SPRITES[key] ? SPRITES[key]() : Promise.resolve(''),
+    defaultSprite: '<%= options.defaultSprite %>',
+    spriteClassPrefix: '<%= options.spriteClassPrefix %>',
+    spriteClass: '<%= options.elementClass %>'
+  }))
 }
-


### PR DESCRIPTION
Improved formatting for plugin template. Improves readily of the rendered plugin file (see bellow). Follows ESLint rules of the repository.

Before:
```js
const SPRITES = {
"dreams": () => import('../../assets/sprite/gen/dreams.svg'),"empty-defs": () => import('../../assets/sprite/gen/empty-defs.svg'),"love": () => import('../../assets/sprite/gen/love.svg'),"icons": () => import('../../assets/sprite/gen/icons.svg')
}

export default function(context, inject) {
    inject('svgSprite', svgSprite({
        importSprite: key => SPRITES[key] ? SPRITES[key]() : Promise.resolve(""),
        defaultSprite: 'icons',
        spriteClassPrefix: 'sprite-',
        spriteClass: 'icon',
    }))
}
```

After:
```js
const SPRITES = {
  'dreams': () => import('../../assets/sprite/gen/dreams.svg'),
  'empty-defs': () => import('../../assets/sprite/gen/empty-defs.svg'),
  'love': () => import('../../assets/sprite/gen/love.svg'),
  'icons': () => import('../../assets/sprite/gen/icons.svg')
}

export default function (_, inject) {
  inject('svgSprite', svgSprite({
    importSprite: key => SPRITES[key] ? SPRITES[key]() : Promise.resolve(''),
    defaultSprite: 'icons',
    spriteClassPrefix: 'sprite-',
    spriteClass: 'icon'
  }))
}
```