### PR TITLE
fix: allow symlinks inside sprite input

### DIFF
--- a/src/svg.ts
+++ b/src/svg.ts
@@ -70,7 +70,7 @@ export default class SVGManager extends Hookable {
         hasDefaultSprite = true
       }
       const stat = await fs.lstat(source)
-      if (stat.isDirectory()) {
+      if (stat.isDirectory() || stat.isSymbolicLink()) {
         await this.createSprite(file, source)
       }
     }


### PR DESCRIPTION
This fix allows creating symlinkins to folders which contain svg sprites. This is really useful as it allows having icon dependencies in the project and then just symlinking to them (f.e. for `bootstrap-icons` you could create a `./assets/sprite/svg/bootstrap` symlink to `../../../node_modules/bootstrap-icons/icons`).