### PR TITLE
Fix for input and output values that include nuxt aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@nuxtjs/svg-sprite",
+    "name": "@gvade/nuxt3-svg-sprite",
     "version": "1.0.0",
     "description": "Easy way to use and optimize svg files in Nuxt.js",
     "repository": "nuxt-community/svg-sprite-module",
@@ -29,18 +29,18 @@
         "test": "vitest run"
     },
     "dependencies": {
-        "@nuxt/kit": "^3.3.2",
-        "svgo": "^3.0.2"
+        "@nuxt/kit": "^3.10.0",
+        "svgo": "^3.2.0"
     },
     "devDependencies": {
         "@nuxt/module-builder": "^0.2.1",
         "@nuxt/test-utils": "latest",
         "@nuxtjs/eslint-config-typescript": "latest",
         "@types/svgo": "^2.6.4",
-        "eslint": "^8.37.0",
-        "nuxt": "^3.3.2",
-        "playwright": "^1.32.1",
-        "release-it": "^15.9.3",
+        "eslint": "^8.56.0",
+        "nuxt": "^3.10.0",
+        "playwright": "^1.41.2",
+        "release-it": "^15.11.0",
         "vitest": "^0.29.8"
     },
     "packageManager": "pnpm@8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gvade/nuxt3-svg-sprite",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Easy way to use and optimize svg files in Nuxt.js",
     "repository": "nuxt-community/svg-sprite-module",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gvade/nuxt3-svg-sprite",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Easy way to use and optimize svg files in Nuxt.js",
     "repository": "nuxt-community/svg-sprite-module",
     "license": "MIT",

--- a/src/module.ts
+++ b/src/module.ts
@@ -128,8 +128,9 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     nuxt.hook('nitro:init', async (nitro) => {
-      const input = options.input.replace(/~|\.\//, 'root').replace(/\//g, ':')
-      const output = options.output.replace(/~\/|\.\//, '')
+      // Support (fix) for default and custom nuxt aliases
+      const input = inputDir.replace(nitro.options.rootDir, '~').replace(/~|\.\//, 'root').replace(/\//g, ':');
+      const output = outDir.replace(nitro.options.rootDir, '').replace(/~\/|\.\//, '');
 
       // Make sure output directory exists and contains .gitignore to ignore sprite files
       if (!await nitro.storage.hasItem(`${output}:.gitignore`)) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -95,6 +95,18 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }).dst
 
+    // Add template
+    // Fix: we need this alias in the svg-icon component independently on the iconsPath setting
+    nuxt.options.alias['#svg-sprite-icons'] = addTemplate({
+      ...iconsTemplate,
+      write: true,
+      options: {
+        sprites,
+        outDir,
+        defaultSprite: options.defaultSprite
+      }
+    }).dst
+
     // Register icons page
     if (options.iconsPath) {
       // Add layout
@@ -102,17 +114,6 @@ export default defineNuxtModule<ModuleOptions>({
         filename: 'svg-sprite.vue',
         src: resolve('./runtime/components/layout.vue')
       })
-
-      // Add template
-      nuxt.options.alias['#svg-sprite-icons'] = addTemplate({
-        ...iconsTemplate,
-        write: true,
-        options: {
-          sprites,
-          outDir,
-          defaultSprite: options.defaultSprite
-        }
-      }).dst
 
       // Register route
       nuxt.hook('pages:extend', (routes) => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -22,6 +22,8 @@ export interface ModuleOptions {
   output: string
   iconsPath: string
   defaultSprite: string
+  elementClass: string
+  spriteClassPrefix: string
   optimizeOptions: SVGOConfig
 }
 
@@ -38,6 +40,8 @@ export default defineNuxtModule<ModuleOptions>({
     output: '~/assets/sprite/gen',
     defaultSprite: 'icons',
     iconsPath: '/_icons',
+    elementClass: 'icon',
+    spriteClassPrefix: 'sprite-',
     optimizeOptions: {
       plugins: [
         {
@@ -91,7 +95,9 @@ export default defineNuxtModule<ModuleOptions>({
       options: {
         sprites,
         outDir,
-        defaultSprite: options.defaultSprite
+        defaultSprite: options.defaultSprite,
+        elementClass: options.elementClass,
+        spriteClassPrefix: options.spriteClassPrefix
       }
     }).dst
 

--- a/src/runtime/composables/useSprite.ts
+++ b/src/runtime/composables/useSprite.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
-import { sprites, defaultSprite, spriteClass, spriteClassPrefix } from '#svg-sprite'
+import {sprites, defaultSprite, spriteClass, spriteClassPrefix} from '#svg-sprite'
 
-function generateName (name: string) {
+function generateName(name: string) {
   return name
     .toLowerCase()
     .replace(/\.svg$/, '')

--- a/src/template.ts
+++ b/src/template.ts
@@ -8,8 +8,8 @@ export const spritesTemplate = {
       'export const sprites = {',
       imports,
       '}',
-      'export const spriteClass = "";\n',
-      'export const spriteClassPrefix = "";\n',
+      `export const spriteClass = "${options.elementClass}";\n`,
+      `export const spriteClassPrefix = "${options.spriteClassPrefix}";\n`,
       `export const defaultSprite = "${options.defaultSprite}";\n`
     ].join('\n')
   }


### PR DESCRIPTION
This PR includes a fix for incorrect resolve of `input` and `output` configuration values with nuxt aliases.
Correspondent bug reports:
#307 
#295 