### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ Sprites help increase speed, maintain a consistent development workflow, and mak
 ## Installation
 
 ```bash
-yarn add @nuxtjs/svg-sprite
-# or
-npm i @nuxtjs/svg-sprite
+npx nuxi@latest module add svg-sprite
 ```
 
 ## Usage

--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -24,18 +24,9 @@ Optimized and Easy way to use SVG files in Nuxt.js
 ::
 
 Add `@nuxtjs/svg-sprite` dependency to your project:
-
-::code-group
-
-```bash [Yarn]
-yarn add --dev @nuxtjs/svg-sprite
+```bash
+npx nuxi@latest module add svg-sprite
 ```
-
-```bash [NPM]
-npm install --save-dev @nuxtjs/svg-sprite
-```
-
-::
 
 Then, add `@nuxtjs/svg-sprite` to the `modules` section of your `nuxt.config.js`
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
