### PR TITLE
fix: #307, #295, #298, #294 and add option to change component name

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -8,8 +8,8 @@ export const spritesTemplate = {
       'export const sprites = {',
       imports,
       '}',
-      'export const spriteClass = "";\n',
-      'export const spriteClassPrefix = "";\n',
+      `export const spriteClass = "${options.elementClass}";\n`,
+      `export const spriteClassPrefix = "${options.spriteClassPrefix}";\n`,
       `export const defaultSprite = "${options.defaultSprite}";\n`
     ].join('\n')
   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description
🐞 This PR includes the fixes #307, #295, #298, #294 (thanks to @AndriiGera) which you can access this PR: #309
✨ And also adds ability to change component name with `componentName` key in the module options,

```
svgSprite: {
  componentName: 'MySvgIcon',
}
```

I've published an npm package by forking this package and including this PR. 
You can install it using `npm install @volkanakkus/nuxt-svg-sprite`, and add `@volkanakkus/nuxt-svg-sprite` to the `modules` section in your `nuxt.config`. You can use my package until this PR is merged.

If you only want the fixes (without component name feature) you can use `@gvade/nuxt3-svg-sprite`.
See more in his PR: #309

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
